### PR TITLE
Add missing 'var'

### DIFF
--- a/autojoin.user.js
+++ b/autojoin.user.js
@@ -42,7 +42,7 @@ function GetCurrentGame()
 	if (gameid > 0)
 	{
 		console.log('Current game: ' + gameid);
-		play_div = document.getElementsByClassName('section_play')[0].children[1].children[0].children[0].children[0];
+		var play_div = document.getElementsByClassName('section_play')[0].children[1].children[0].children[0].children[0];
 		var paren_pos = play_div.innerHTML.search('[(]');
 		var btn_text = play_div.innerHTML;
 		if (paren_pos > 0) btn_text = play_div.innerHTML.substr(0,paren_pos-1);


### PR DESCRIPTION
This missing var was causing an error in the console and was causing the script to not work, specifically if you tried to use the script while already in a room. Nothing would show up on the minigame page. Adding the missing var fixes the problem.
