### PR TITLE
Fix match URL bug

### DIFF
--- a/autojoin.user.js
+++ b/autojoin.user.js
@@ -6,7 +6,8 @@
 // @author	geekahedron
 // @match	*://steamcommunity.com/minigame
 // @match	*://steamcommunity.com//minigame
-// @match	http://steamcommunity.com/minigame/
+// @match	*://steamcommunity.com/minigame/
+// @match	*://steamcommunity.com//minigame/
 // @updateURL	https://raw.githubusercontent.com/geekahedron/SteamGameAutoJoin/master/autojoin.user.js
 // @downloadURL	https://raw.githubusercontent.com/geekahedron/SteamGameAutoJoin/master/autojoin.user.js
 // @grant	none


### PR DESCRIPTION
Fix the origin match rule doesn't match steamcommunity.com//minigame/
